### PR TITLE
Set dinosaur type on init

### DIFF
--- a/Assets/Prefabs/Tile.prefab
+++ b/Assets/Prefabs/Tile.prefab
@@ -289,8 +289,8 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -416223551
-  m_SortingLayer: 1
-  m_SortingOrder: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 1
   m_Sprite: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0

--- a/Assets/Scripts/Tile.cs
+++ b/Assets/Scripts/Tile.cs
@@ -13,17 +13,29 @@ public class Tile : MonoBehaviour
     [SerializeField] private Sprite[] _dinoArray;
 
 
-    enum Dinosaur {
-        Stegosaurus,
-        Velociraptor
+    enum Dinosaur
+    {
+        Dinosaur,
+        Brachiosaurus,
+        Stegosaurus
     }
 
     public void Init()
     {
+        InitTile();
+        InitDinosaur();
+    }
+
+    private void InitTile()
+    {
         _renderer.flipX = getRandomBoolean();
         _renderer.flipY = getRandomBoolean();
-        _dinosaurTile.GetComponent<SpriteRenderer>().sprite = _dinoArray[Random.Range(0,_dinoArray.Length)];
-
+    }
+    private void InitDinosaur()
+    {
+        Dinosaur randomDinosaur = getRandomDinosaurType();
+        _dinosaurTile.GetComponent<SpriteRenderer>().sprite = _dinoArray[(int)randomDinosaur];
+        _dinosaurType = randomDinosaur;
     }
 
     private Dinosaur getRandomDinosaurType()


### PR DESCRIPTION
Fix bug where when a tile is generated, it's type does not match the sprite.